### PR TITLE
sets bee command to execute in the target cli mode

### DIFF
--- a/.docksal/commands/bee
+++ b/.docksal/commands/bee
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+#: exec_target = cli
+
 ## Run a bee command inside the cli container.
 ##
 ## Usage: fin bee [command]
@@ -13,4 +15,4 @@ DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT}"
 
 #-------------------------- END: Settings --------------------------------
 
-fin exec /usr/local/bin/bee/bee.php --root=${DOCROOT_PATH} "$@"
+/usr/local/bin/bee/bee.php --root=${DOCROOT_PATH} "$@"


### PR DESCRIPTION
Fixes #42 

By changing the target mode of the command, it will run where the `/usr/local/bin` directory is from inside the container and not the local host usr directory.